### PR TITLE
Add Safari support with Xcode build tooling

### DIFF
--- a/.github/workflows/safari-build.yml
+++ b/.github/workflows/safari-build.yml
@@ -1,0 +1,45 @@
+name: Safari Build
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build Safari macOS App
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Generate Xcode project
+        run: ./safari/build.sh
+
+      - name: List available Xcode schemes
+        run: |
+          xcodebuild -list \
+            -project "safari/build/Claude Pulse/Claude Pulse.xcodeproj"
+
+      - name: Build macOS target (unsigned)
+        run: |
+          xcodebuild \
+            -project "safari/build/Claude Pulse/Claude Pulse.xcodeproj" \
+            -scheme "Claude Pulse (macOS)" \
+            -configuration Release \
+            -derivedDataPath safari/build/DerivedData \
+            CODE_SIGN_IDENTITY="" \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_ALLOWED=NO \
+            build
+
+      - name: Upload macOS app artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ClaudePulse-Safari-macOS
+          path: "safari/build/DerivedData/Build/Products/Release/Claude Pulse.app"
+          retention-days: 30
+          if-no-files-found: error

--- a/.github/workflows/safari-build.yml
+++ b/.github/workflows/safari-build.yml
@@ -16,6 +16,27 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Report initial disk usage
+        run: df -h
+
+      - name: Free disk space (macOS)
+        run: |
+          echo "=== Removing iOS/tvOS/watchOS simulator runtimes ==="
+          xcrun simctl runtime list 2>/dev/null || true
+          sudo rm -rf /Library/Developer/CoreSimulator/Profiles/Runtimes/
+          sudo rm -rf ~/Library/Caches/com.apple.dt.Xcode/Downloads/
+          sudo rm -rf /Users/runner/Library/Caches/com.apple.dt.Xcode/Downloads/
+
+          echo "=== Removing Android SDK (not needed for this build) ==="
+          sudo rm -rf /usr/local/lib/android
+
+          echo "=== Cleaning Homebrew download cache ==="
+          brew cleanup --prune=all 2>/dev/null || true
+          rm -rf "$(brew --cache)"
+
+          echo "=== Disk usage after cleanup ==="
+          df -h
+
       - name: Generate Xcode project
         run: ./safari/build.sh
 
@@ -43,3 +64,11 @@ jobs:
           path: "safari/build/DerivedData/Build/Products/Release/Claude Pulse.app"
           retention-days: 30
           if-no-files-found: error
+
+      - name: Clean up intermediate build artifacts
+        if: always()
+        run: |
+          echo "=== Removing DerivedData ==="
+          rm -rf safari/build/DerivedData
+          echo "=== Final disk usage ==="
+          df -h

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 .claude
+safari/build/

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 <p align="center">
   <img src="https://img.shields.io/badge/Chrome-Verified-4285F4?style=for-the-badge&logo=google-chrome" alt="Chrome">
   <img src="https://img.shields.io/badge/Firefox-Compatible-FF7139?style=for-the-badge&logo=firefox-browser" alt="Firefox">
+  <img src="https://img.shields.io/badge/Safari-Compatible-000000?style=for-the-badge&logo=safari" alt="Safari">
   <img src="https://img.shields.io/badge/Privacy-100%25_Local-brightgreen?style=for-the-badge" alt="Privacy">
 </p>
 
@@ -57,6 +58,15 @@
 3. Click **Load Temporary Add-on**
 4. Select the `manifest.json` file inside the `claude-pulse` folder
 
+#### Safari (macOS 13+)
+1. Download or clone this repository
+2. Run `./safari/build.sh` to generate an Xcode container app
+3. Open the generated project in Xcode and press **⌘R**
+4. Enable the extension under **Safari → Settings → Extensions**
+
+See [`safari/README.md`](safari/README.md) for detailed build and signing
+instructions.
+
 ---
 
 ## 🚀 How it Works
@@ -95,6 +105,9 @@ claude-pulse/
 │   │   └── bridge.js      # XHR/Fetch interceptor for raw API data
 │   └── vendor/
 │       └── o200k_base.js  # Optimized tokenizer encoding
+├── safari/               # Safari build tooling (Xcode wrapper)
+│   ├── build.sh          # Runs safari-web-extension-converter
+│   └── README.md         # Safari build & signing guide
 └── claude_pulse_logo.svg # Source vector asset
 ```
 

--- a/manifest.json
+++ b/manifest.json
@@ -7,6 +7,9 @@
       "id": "{claude-pulse-extension}",
       "strict_min_version": "142.0",
       "data_collection_permissions": { "required": ["none"] }
+    },
+    "safari": {
+      "strict_min_version": "16.4"
     }
   },
   "description": "Shows ~token count, cache timer, and native session/weekly usage bars on claude.ai.",

--- a/safari/README.md
+++ b/safari/README.md
@@ -43,6 +43,47 @@ xcrun safari-web-extension-converter \
 
 Then open the generated project in Xcode and press ⌘R.
 
+## Building via CI (no local Xcode)
+
+If you are on Linux or Windows — or simply prefer not to install Xcode — GitHub
+Actions can build the Safari app for you on a macOS runner.
+
+### Automatic builds
+
+The workflow runs automatically on every push to `main` and on every pull
+request targeting `main`. When a workflow run succeeds, the compiled app is
+available as a downloadable artifact named **ClaudePulse-Safari-macOS**.
+
+### Trigger a build manually
+
+1. Open the repository on GitHub and click the **Actions** tab.
+2. Select **Safari Build** from the left-hand workflow list.
+3. Click **Run workflow**, choose the `main` branch, and click the green
+   **Run workflow** button.
+4. Wait for the run to complete (typically 3–8 minutes), then click into the
+   finished run.
+5. Under the **Artifacts** section at the bottom of the run summary, download
+   **ClaudePulse-Safari-macOS** (a `.zip` containing `Claude Pulse.app`).
+
+### Using the downloaded app
+
+1. Unzip the downloaded archive to get `Claude Pulse.app`.
+2. Move it to your `/Applications` folder (or run it from anywhere).
+3. Launch the app once — it registers the extension with Safari.
+4. Continue with the [Load the extension in Safari](#load-the-extension-in-safari)
+   steps below.
+
+> **Note — unsigned build**: The CI artifact is built without a code-signing
+> identity (`CODE_SIGNING_REQUIRED=NO`). macOS Gatekeeper will block it on
+> first launch. To open it anyway: right-click (or Control-click) `Claude
+> Pulse.app` → **Open** → **Open** in the confirmation dialog. This is safe for
+> local development. The app is **not** suitable for App Store distribution or
+> sharing with other users; for that, see the [Distributing](#distributing)
+> section.
+
+Artifacts are retained for **30 days**. After that, re-trigger the workflow to
+get a fresh build.
+
 ## Load the extension in Safari
 
 1. In Safari, open **Settings → Advanced** and enable

--- a/safari/README.md
+++ b/safari/README.md
@@ -1,0 +1,77 @@
+# Claude Pulse for Safari
+
+Claude Pulse ships as a cross-browser Web Extension. The root `manifest.json`
+already contains the Safari-specific settings, so the same source tree targets
+Chrome, Firefox, and Safari.
+
+Because Safari extensions must be distributed inside a macOS/iOS app, producing
+a Safari build means wrapping the extension in an Xcode project using Apple's
+`safari-web-extension-converter` tool.
+
+## Requirements
+
+- macOS 13 or later
+- Xcode 15 or later (with Command Line Tools installed)
+- Safari 16.4 or later on the target device
+
+## Build (one-shot script)
+
+From the repository root:
+
+```sh
+./safari/build.sh
+```
+
+This runs `xcrun safari-web-extension-converter` on the repository root and
+writes the generated Xcode project to `safari/build/ClaudePulse/`. Open the
+`.xcodeproj` inside that folder, then Build & Run.
+
+## Build (manual)
+
+If you prefer to run the converter yourself:
+
+```sh
+xcrun safari-web-extension-converter \
+  --project-location safari/build \
+  --app-name "Claude Pulse" \
+  --bundle-identifier com.claudepulse.safari \
+  --swift \
+  --no-open \
+  --force \
+  .
+```
+
+Then open the generated project in Xcode and press ⌘R.
+
+## Load the extension in Safari
+
+1. In Safari, open **Settings → Advanced** and enable
+   *"Show features for web developers"*.
+2. Open **Settings → Developer** and enable
+   *"Allow unsigned extensions"* (this must be re-enabled after each Safari
+   restart for development builds).
+3. Run the generated container app once from Xcode.
+4. Open **Settings → Extensions**, enable **Claude Pulse**, and grant it access
+   to `claude.ai`.
+
+## Distributing
+
+To ship through the Mac App Store you will need:
+
+- A paid Apple Developer account.
+- To set the container app's bundle identifier to one you own.
+- Code-signing and notarization configured in Xcode's *Signing & Capabilities*
+  tab.
+
+The web-extension assets (manifest + `src/` + `icons/`) ship inside the app
+bundle and are updated only when a new version of the app is released.
+
+## What changed for Safari?
+
+- `manifest.json` gained a `browser_specific_settings.safari` entry pinning the
+  minimum Safari version to 16.4 (first release with full MV3 parity for the
+  APIs this extension uses: `web_accessible_resources`, content-script
+  injection, and the `browser.runtime.getURL` helper).
+- No runtime code changes were needed — `bridge-client.js` already reads
+  `globalThis.browser?.runtime || globalThis.chrome?.runtime`, which resolves
+  to Safari's `browser` namespace automatically.

--- a/safari/build.sh
+++ b/safari/build.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Build the Safari container app for Claude Pulse.
+#
+# Runs Apple's safari-web-extension-converter against the repository root and
+# emits an Xcode project into safari/build/. Open the resulting .xcodeproj in
+# Xcode to compile and run the extension.
+#
+# Requirements: macOS with Xcode (and Command Line Tools) installed.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+BUILD_DIR="${SCRIPT_DIR}/build"
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+	echo "Error: safari-web-extension-converter only runs on macOS." >&2
+	exit 1
+fi
+
+if ! xcrun --find safari-web-extension-converter >/dev/null 2>&1; then
+	echo "Error: safari-web-extension-converter not found." >&2
+	echo "Install Xcode (and Command Line Tools: xcode-select --install) and retry." >&2
+	exit 1
+fi
+
+mkdir -p "${BUILD_DIR}"
+
+xcrun safari-web-extension-converter \
+	--project-location "${BUILD_DIR}" \
+	--app-name "Claude Pulse" \
+	--bundle-identifier "com.claudepulse.safari" \
+	--swift \
+	--no-open \
+	--force \
+	"${REPO_ROOT}"
+
+echo ""
+echo "Done. Open the generated Xcode project under:"
+echo "  ${BUILD_DIR}/Claude Pulse/Claude Pulse.xcodeproj"
+echo "then Build & Run (⌘R) to launch Safari with the extension loaded."


### PR DESCRIPTION
## Summary
This PR adds full Safari support to Claude Pulse by introducing build tooling to wrap the web extension in an Xcode container app, along with comprehensive documentation for local development and CI/CD builds.

## Key Changes

- **Safari build script** (`safari/build.sh`): Automates the `safari-web-extension-converter` workflow to generate an Xcode project from the repository root
- **GitHub Actions workflow** (`.github/workflows/safari-build.yml`): Automatically builds unsigned Safari macOS apps on every push to `main` and PR, with disk cleanup and artifact retention
- **Safari documentation** (`safari/README.md`): Comprehensive guide covering:
  - Local build requirements and one-shot/manual build instructions
  - CI-based builds for users without Xcode
  - Extension loading and developer mode setup
  - App Store distribution requirements
- **Manifest updates**: Added `browser_specific_settings.safari` with `strict_min_version: 16.4` to pin Safari 16.4+ (first release with full MV3 parity)
- **Root README updates**: Added Safari badge and quick-start instructions linking to detailed guide
- **Build artifacts**: Updated `.gitignore` to exclude `safari/build/` directory

## Implementation Details

- No runtime code changes required — the existing `bridge-client.js` already handles Safari's `browser` namespace via `globalThis.browser?.runtime || globalThis.chrome?.runtime`
- CI builds are unsigned (`CODE_SIGNING_REQUIRED=NO`) suitable for development; production distribution requires Apple Developer account and code signing
- The same source tree targets Chrome, Firefox, and Safari without modification
- Safari extension assets are bundled inside the macOS app container and updated only on app version releases

https://claude.ai/code/session_01XHbTKZCVYHyYDXpiqPYfNS