### PR TITLE
feat(ui): usage strip, refresh control, and tighter copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@
 
 ### 📥 Installation
 
-#### Live Link 
-[Claude Pulse – Chrome Web Store](https://chromewebstore.google.com/detail/claude-pulse/hhjihbpkopgacncfbkdakdolkmgkdfnf)
+#### Chrome Web Store
+[Claude Pulse on the Chrome Web Store](https://chromewebstore.google.com/detail/claude-pulse/hhjihbpkopgacncfbkdakdolkmgkdfnf)
 
 
 #### Chrome / Brave / Edge
@@ -82,7 +82,7 @@ Claude Pulse provides a transparent look into the "invisible" metrics of your Cl
 ```
 claude-pulse/
 ├── manifest.json         # Extension configuration & permissions
-├── icons/                # Extension branding (PNAs)
+├── icons/                # Extension branding (PNGs)
 ├── src/
 │   ├── styles.css        # Premium UI styling & animations
 │   ├── content/

--- a/manifest.json
+++ b/manifest.json
@@ -9,7 +9,7 @@
       "data_collection_permissions": { "required": ["none"] }
     }
   },
-  "description": "Shows ~token count, cache timer, and native session/weekly usage bars on claude.ai.",
+  "description": "Approximate token count, prompt-cache countdown, and 5-hour / 7-day usage bars on claude.ai. All metrics are computed locally in your browser.",
   "icons": {
     "16": "icons/icon16.png",
     "32": "icons/icon32.png",

--- a/src/content/main.js
+++ b/src/content/main.js
@@ -123,6 +123,7 @@
 	let usageFetchInFlight = false;
 	let lastUsageUpdateMs = 0;
 	const rolloverHandledForResetMs = { five_hour: null, seven_day: null };
+	let lastPeriodicUsageRefreshMs = Date.now();
 
 	const ui = new CC.ui.CounterUI({
 		onUsageRefresh: async () => {
@@ -176,6 +177,7 @@
 
 		const parsed = parseUsageFromUsageEndpoint(raw);
 		applyUsageUpdate(parsed, 'usage');
+		lastPeriodicUsageRefreshMs = Date.now();
 	}
 
 	async function refreshConversation() {
@@ -311,6 +313,13 @@
 			now - lastUsageSseMs > ONE_HOUR_MS &&
 			now - lastUsageUpdateMs > ONE_HOUR_MS
 		) {
+			refreshUsage();
+		}
+
+		// Periodic usage refresh every 2 minutes while tab is visible (no on-screen “last updated” label)
+		const TWO_MIN_MS = 2 * 60 * 1000;
+		if (!document.hidden && now - lastPeriodicUsageRefreshMs >= TWO_MIN_MS) {
+			lastPeriodicUsageRefreshMs = now;
 			refreshUsage();
 		}
 	}

--- a/src/content/ui.js
+++ b/src/content/ui.js
@@ -39,6 +39,43 @@
 		return `~${count}`;
 	}
 
+	const LENGTH_TOOLTIP_DEFAULT = 'Estimated tokens (~)';
+
+	function formatUsageStripText(rawPct, resetMs) {
+		const used = Math.round(rawPct * 10) / 10;
+		const parts = [`${used}% used`];
+		if (resetMs != null && Number.isFinite(resetMs)) {
+			parts.push(`resets in ${formatResetCountdown(resetMs)}`);
+		}
+		return parts.join(' · ');
+	}
+
+	function formatRelativeUpdated(tsMs) {
+		if (typeof tsMs !== 'number' || !Number.isFinite(tsMs)) return '';
+		const sec = Math.max(0, Math.floor((Date.now() - tsMs) / 1000));
+		if (sec < 10) return 'now';
+		if (sec < 60) return `${sec}s`;
+		const min = Math.floor(sec / 60);
+		if (min < 60) return `${min}m`;
+		const h = Math.floor(min / 60);
+		if (h < 48) return `${h}h`;
+		const d = Math.floor(h / 24);
+		return `${d}d`;
+	}
+
+	function formatRelativeUpdatedTitle(tsMs) {
+		if (typeof tsMs !== 'number' || !Number.isFinite(tsMs)) return '';
+		const sec = Math.max(0, Math.floor((Date.now() - tsMs) / 1000));
+		if (sec < 8) return 'Last updated just now';
+		if (sec < 60) return `Last updated ${sec} seconds ago`;
+		const min = Math.floor(sec / 60);
+		if (min < 60) return `Last updated ${min} minutes ago`;
+		const h = Math.floor(min / 60);
+		if (h < 48) return `Last updated ${h} hours ago`;
+		const d = Math.floor(h / 24);
+		return `Last updated ${d} days ago`;
+	}
+
 	// ── Tooltip system ──
 
 	function setupTooltip(element, tooltip, { topOffset = 10 } = {}) {
@@ -126,19 +163,24 @@
 			this.pendingCache = false;
 
 			this.usageLine = null;
-			this.sessionUsageSpan = null;
-			this.weeklyUsageSpan = null;
+			this.sessionTitleSpan = null;
+			this.sessionInlineSpan = null;
+			this.weeklyTitleSpan = null;
+			this.weeklyInlineSpan = null;
+			this._sessionUtilPct = null;
+			this._weeklyUtilPct = null;
 			this.sessionBar = null;
 			this.sessionBarFill = null;
 			this.weeklyBar = null;
 			this.weeklyBarFill = null;
 			this.sessionResetMs = null;
 			this.weeklyResetMs = null;
-			this.sessionMarker = null;
-			this.weeklyMarker = null;
-			this.sessionWindowStartMs = null;
-			this.weeklyWindowStartMs = null;
 			this.refreshingUsage = false;
+
+			this.usageMetaGroup = null;
+			this.usageLastUpdatedSpan = null;
+			this.usageRefreshBtn = null;
+			this.usageLastUpdatedMs = null;
 
 			this.domObserver = null;
 		}
@@ -246,86 +288,125 @@
 		_initUsageLine() {
 			this.usageLine = document.createElement('div');
 			this.usageLine.className =
-				'text-text-400 text-[11px] cc-usageRow cc-hidden flex flex-row items-center gap-3 w-full';
-
-			this.sessionUsageSpan = document.createElement('span');
-			this.sessionUsageSpan.className = 'cc-usageText';
-
-			this.sessionBar = document.createElement('div');
-			this.sessionBar.className = 'cc-bar cc-bar--usage';
-			this.sessionBarFill = document.createElement('div');
-			this.sessionBarFill.className = 'cc-bar__fill';
-			this.sessionMarker = document.createElement('div');
-			this.sessionMarker.className = 'cc-bar__marker cc-hidden';
-			this.sessionMarker.style.left = '0%';
-			this.sessionBar.appendChild(this.sessionBarFill);
-			this.sessionBar.appendChild(this.sessionMarker);
-
-			this.weeklyUsageSpan = document.createElement('span');
-			this.weeklyUsageSpan.className = 'cc-usageText';
-
-			this.weeklyBar = document.createElement('div');
-			this.weeklyBar.className = 'cc-bar cc-bar--usage';
-			this.weeklyBarFill = document.createElement('div');
-			this.weeklyBarFill.className = 'cc-bar__fill';
-			this.weeklyMarker = document.createElement('div');
-			this.weeklyMarker.className = 'cc-bar__marker cc-hidden';
-			this.weeklyMarker.style.left = '0%';
-			this.weeklyBar.appendChild(this.weeklyBarFill);
-			this.weeklyBar.appendChild(this.weeklyMarker);
+				'text-text-400 text-[11px] cc-usageRow cc-hidden flex flex-row flex-nowrap items-center gap-3 w-full';
 
 			this.sessionGroup = document.createElement('div');
-			this.sessionGroup.className = 'cc-usageGroup';
-			this.sessionGroup.appendChild(this.sessionUsageSpan);
+			this.sessionGroup.className = 'cc-usageGroup cc-usageStrip';
+
+			this.sessionTitleSpan = document.createElement('span');
+			this.sessionTitleSpan.className = 'cc-usageStrip__label';
+			this.sessionTitleSpan.textContent = '5h';
+
+			this.sessionBar = document.createElement('div');
+			this.sessionBar.className = 'cc-bar cc-bar--mini cc-usageStrip__bar';
+			this.sessionBarFill = document.createElement('div');
+			this.sessionBarFill.className = 'cc-bar__fill';
+			this.sessionBar.appendChild(this.sessionBarFill);
+
+			this.sessionInlineSpan = document.createElement('span');
+			this.sessionInlineSpan.className = 'cc-usageStrip__meta';
+
+			this.sessionGroup.appendChild(this.sessionTitleSpan);
 			this.sessionGroup.appendChild(this.sessionBar);
+			this.sessionGroup.appendChild(this.sessionInlineSpan);
 
 			this.weeklyGroup = document.createElement('div');
-			this.weeklyGroup.className = 'cc-usageGroup cc-usageGroup--weekly';
+			this.weeklyGroup.className = 'cc-usageGroup cc-usageStrip cc-usageStrip--end';
+
+			this.weeklyTitleSpan = document.createElement('span');
+			this.weeklyTitleSpan.className = 'cc-usageStrip__label';
+			this.weeklyTitleSpan.textContent = '7d';
+
+			this.weeklyBar = document.createElement('div');
+			this.weeklyBar.className = 'cc-bar cc-bar--mini cc-usageStrip__bar';
+			this.weeklyBarFill = document.createElement('div');
+			this.weeklyBarFill.className = 'cc-bar__fill';
+			this.weeklyBar.appendChild(this.weeklyBarFill);
+
+			this.weeklyInlineSpan = document.createElement('span');
+			this.weeklyInlineSpan.className = 'cc-usageStrip__meta';
+
+			this.weeklyGroup.appendChild(this.weeklyTitleSpan);
 			this.weeklyGroup.appendChild(this.weeklyBar);
-			this.weeklyGroup.appendChild(this.weeklyUsageSpan);
+			this.weeklyGroup.appendChild(this.weeklyInlineSpan);
 
 			this.usageLine.appendChild(this.sessionGroup);
 			this.usageLine.appendChild(this.weeklyGroup);
 
-			this.refreshProgressChrome();
+			this.usageMetaGroup = document.createElement('div');
+			this.usageMetaGroup.className = 'cc-usageMeta';
 
-			this.usageLine.addEventListener('click', async () => {
-				if (!this.onUsageRefresh || this.refreshingUsage) return;
-				this.refreshingUsage = true;
-				this.usageLine.classList.add('cc-usageRow--dim');
+			this.usageLastUpdatedSpan = document.createElement('span');
+			this.usageLastUpdatedSpan.className = 'cc-usageMetaUpdated';
+			this.usageLastUpdatedSpan.setAttribute('aria-live', 'polite');
 
-				// Spin logo on refresh
-				this.logoContainer.classList.add('cc-logo--spinning');
-				try {
-					await this.onUsageRefresh();
-				} finally {
-					this.usageLine.classList.remove('cc-usageRow--dim');
-					this.logoContainer.classList.remove('cc-logo--spinning');
-					this.refreshingUsage = false;
-				}
+			this.usageRefreshBtn = document.createElement('button');
+			this.usageRefreshBtn.type = 'button';
+			this.usageRefreshBtn.className = 'cc-usageRefresh cc-tooltipTrigger';
+			this.usageRefreshBtn.setAttribute('aria-label', 'Refresh usage');
+			this.usageRefreshBtn.innerHTML = `
+				<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+					<path d="M23 4v6h-6"></path>
+					<path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"></path>
+				</svg>
+			`;
+			this.usageRefreshBtn.addEventListener('click', (e) => {
+				e.preventDefault();
+				e.stopPropagation();
+				this._refreshUsage();
 			});
+
+			this.usageMetaGroup.appendChild(this.usageLastUpdatedSpan);
+			this.usageMetaGroup.appendChild(this.usageRefreshBtn);
+			this.usageLine.appendChild(this.usageMetaGroup);
+
+			this.refreshProgressChrome();
+		}
+
+		async _refreshUsage() {
+			if (!this.onUsageRefresh || this.refreshingUsage) return;
+			this.refreshingUsage = true;
+			this.usageRefreshBtn.disabled = true;
+			this.usageRefreshBtn.classList.add('cc-usageRefresh--busy');
+			this.usageMetaGroup?.classList.add('cc-usageMeta--busy');
+			try {
+				await this.onUsageRefresh();
+			} finally {
+				this.usageRefreshBtn.disabled = false;
+				this.usageRefreshBtn.classList.remove('cc-usageRefresh--busy');
+				this.usageMetaGroup?.classList.remove('cc-usageMeta--busy');
+				this.refreshingUsage = false;
+			}
+		}
+
+		_renderUsageLastUpdated() {
+			if (!this.usageLastUpdatedSpan) return;
+			if (this.usageLastUpdatedMs == null) {
+				this.usageLastUpdatedSpan.textContent = '';
+				this.usageLastUpdatedSpan.removeAttribute('title');
+				return;
+			}
+			this.usageLastUpdatedSpan.textContent = formatRelativeUpdated(this.usageLastUpdatedMs);
+			this.usageLastUpdatedSpan.title = formatRelativeUpdatedTitle(this.usageLastUpdatedMs);
 		}
 
 		_setupTooltips() {
-			this.lengthTooltip = makeTooltip(
-				"Approximate token count · excludes system prompt\n200k context limit · compacts before reaching it\nGeneric tokenizer — may differ slightly from Claude's"
-			);
+			this.lengthTooltip = makeTooltip(LENGTH_TOOLTIP_DEFAULT);
 			setupTooltip(this.lengthGroup, this.lengthTooltip, { topOffset: 8 });
 
-			setupTooltip(
-				this.cachedDisplay,
-				makeTooltip('Messages sent while cached cost significantly less.'),
-				{ topOffset: 8 }
-			);
+			setupTooltip(this.cachedDisplay, makeTooltip('Prompt cache'), { topOffset: 8 });
 
-			this._copyTooltip = makeTooltip('Export chat history');
+			this._copyTooltip = makeTooltip('Copy chat');
 			setupTooltip(this.copyButton, this._copyTooltip, { topOffset: 8 });
 
-			this._sessionTooltip = makeTooltip('5-hour session window\nBar = usage · Line = time position\nClick to refresh');
+			this._sessionTooltip = makeTooltip('5-hour session limit');
 			setupTooltip(this.sessionGroup, this._sessionTooltip, { topOffset: 8 });
 
-			this._weeklyTooltip = makeTooltip('7-day rolling window\nBar = usage · Line = time position\nClick to refresh');
+			this._weeklyTooltip = makeTooltip('7-day limit');
 			setupTooltip(this.weeklyGroup, this._weeklyTooltip, { topOffset: 8 });
+
+			this._usageRefreshTooltip = makeTooltip('Refresh usage');
+			setupTooltip(this.usageRefreshBtn, this._usageRefreshTooltip, { topOffset: 8 });
 		}
 
 		attach() {
@@ -414,11 +495,11 @@
 				this.lengthBar = null;
 				this.lengthGroup.replaceChildren(this.lengthDisplay);
 				if (this.lengthTooltip) {
-					this.lengthTooltip.textContent =
-						"Token count invalid after context compaction\nGeneric tokenizer · excludes system prompt";
+					this.lengthTooltip.textContent = 'Unavailable after compaction';
 				}
 			} else {
 				this.lengthDisplay.style.opacity = '';
+				if (this.lengthTooltip) this.lengthTooltip.textContent = LENGTH_TOOLTIP_DEFAULT;
 				const bar = document.createElement('div');
 				bar.className = 'cc-bar cc-bar--mini';
 				this.lengthBar = bar;
@@ -501,17 +582,8 @@
 
 			if (session && typeof session.utilization === 'number') {
 				const rawPct = session.utilization;
-				const pct = Math.round(rawPct * 10) / 10;
+				this._sessionUtilPct = rawPct;
 				this.sessionResetMs = session.resets_at ? Date.parse(session.resets_at) : null;
-				this.sessionWindowStartMs = this.sessionResetMs ? this.sessionResetMs - 5 * 60 * 60 * 1000 : null;
-
-				// Compact label: "5h 42.3%"
-				this.sessionUsageSpan.textContent = `5h ${pct}%`;
-
-				// Update tooltip with reset info
-				if (this._sessionTooltip && this.sessionResetMs) {
-					this._sessionTooltip.textContent = `5-hour session window\nBar = usage · Line = time position\nResets in ${formatResetCountdown(this.sessionResetMs)}\nClick to refresh`;
-				}
 
 				const width = Math.max(0, Math.min(100, rawPct));
 				this.sessionBarFill.style.width = `${width}%`;
@@ -520,11 +592,11 @@
 				this.sessionBarFill.classList.remove('cc-full');
 				if (width >= 99.5) this.sessionBarFill.classList.add('cc-full');
 			} else {
-				this.sessionUsageSpan.textContent = '';
+				this._sessionUtilPct = null;
+				if (this.sessionInlineSpan) this.sessionInlineSpan.textContent = '';
 				this.sessionBarFill.style.width = '0%';
 				this.sessionBarFill.classList.remove('cc-warn', 'cc-critical', 'cc-full');
 				this.sessionResetMs = null;
-				this.sessionWindowStartMs = null;
 			}
 
 			const hasWeekly = weekly && typeof weekly.utilization === 'number';
@@ -532,21 +604,9 @@
 			this.sessionGroup?.classList.toggle('cc-usageGroup--single', !hasWeekly);
 
 			if (hasWeekly) {
-				this.weeklyUsageSpan.classList.remove('cc-hidden');
-				this.weeklyBar.classList.remove('cc-hidden');
-
 				const rawPct = weekly.utilization;
-				const pct = Math.round(rawPct * 10) / 10;
+				this._weeklyUtilPct = rawPct;
 				this.weeklyResetMs = weekly.resets_at ? Date.parse(weekly.resets_at) : null;
-				this.weeklyWindowStartMs = this.weeklyResetMs ? this.weeklyResetMs - 7 * 24 * 60 * 60 * 1000 : null;
-
-				// Compact label: "7d 18.2%"
-				this.weeklyUsageSpan.textContent = `7d ${pct}%`;
-
-				// Update tooltip with reset info
-				if (this._weeklyTooltip && this.weeklyResetMs) {
-					this._weeklyTooltip.textContent = `7-day rolling window\nBar = usage · Line = time position\nResets in ${formatResetCountdown(this.weeklyResetMs)}\nClick to refresh`;
-				}
 
 				const width = Math.max(0, Math.min(100, rawPct));
 				this.weeklyBarFill.style.width = `${width}%`;
@@ -555,39 +615,41 @@
 				this.weeklyBarFill.classList.remove('cc-full');
 				if (width >= 99.5) this.weeklyBarFill.classList.add('cc-full');
 			} else {
-				this.weeklyUsageSpan.classList.add('cc-hidden');
-				this.weeklyBar.classList.add('cc-hidden');
+				this._weeklyUtilPct = null;
+				if (this.weeklyInlineSpan) this.weeklyInlineSpan.textContent = '';
 				this.weeklyResetMs = null;
-				this.weeklyWindowStartMs = null;
+				this.weeklyBarFill.style.width = '0%';
 				this.weeklyBarFill.classList.remove('cc-warn', 'cc-critical', 'cc-full');
 			}
 
-			this._updateMarkers();
-		}
-
-		_updateMarkers() {
-			const now = Date.now();
-
-			if (this.sessionMarker && this.sessionWindowStartMs && this.sessionResetMs) {
-				const total = this.sessionResetMs - this.sessionWindowStartMs;
-				const elapsed = Math.max(0, Math.min(total, now - this.sessionWindowStartMs));
-				const ratio = total > 0 ? elapsed / total : 0;
-				const pct = Math.max(0, Math.min(100, ratio * 100));
-				this.sessionMarker.classList.remove('cc-hidden');
-				this.sessionMarker.style.left = `${pct}%`;
-			} else if (this.sessionMarker) {
-				this.sessionMarker.classList.add('cc-hidden');
+			if (hasAnyUsage) {
+				this.usageLastUpdatedMs = Date.now();
+				this._renderUsageLastUpdated();
 			}
 
-			if (this.weeklyMarker && this.weeklyWindowStartMs && this.weeklyResetMs) {
-				const total = this.weeklyResetMs - this.weeklyWindowStartMs;
-				const elapsed = Math.max(0, Math.min(total, now - this.weeklyWindowStartMs));
-				const ratio = total > 0 ? elapsed / total : 0;
-				const pct = Math.max(0, Math.min(100, ratio * 100));
-				this.weeklyMarker.classList.remove('cc-hidden');
-				this.weeklyMarker.style.left = `${pct}%`;
-			} else if (this.weeklyMarker) {
-				this.weeklyMarker.classList.add('cc-hidden');
+			this._renderUsageStripText();
+		}
+
+		_renderUsageStripText() {
+			if (this.sessionInlineSpan) {
+				if (typeof this._sessionUtilPct === 'number') {
+					this.sessionInlineSpan.textContent = formatUsageStripText(
+						this._sessionUtilPct,
+						this.sessionResetMs
+					);
+				} else {
+					this.sessionInlineSpan.textContent = '';
+				}
+			}
+			if (this.weeklyInlineSpan) {
+				if (typeof this._weeklyUtilPct === 'number') {
+					this.weeklyInlineSpan.textContent = formatUsageStripText(
+						this._weeklyUtilPct,
+						this.weeklyResetMs
+					);
+				} else {
+					this.weeklyInlineSpan.textContent = '';
+				}
 			}
 		}
 
@@ -607,16 +669,8 @@
 				this._renderHeader();
 			}
 
-			// Update tooltip reset countdown (progressive disclosure)
-			if (this._sessionTooltip && this.sessionResetMs) {
-				this._sessionTooltip.textContent = `5-hour session window\nBar = usage · Line = time position\nResets in ${formatResetCountdown(this.sessionResetMs)}\nClick to refresh`;
-			}
-
-			if (this._weeklyTooltip && this.weeklyResetMs) {
-				this._weeklyTooltip.textContent = `7-day rolling window\nBar = usage · Line = time position\nResets in ${formatResetCountdown(this.weeklyResetMs)}\nClick to refresh`;
-			}
-
-			this._updateMarkers();
+			this._renderUsageLastUpdated();
+			this._renderUsageStripText();
 		}
 
 		// ── Copy button + dropdown ──

--- a/src/content/ui.js
+++ b/src/content/ui.js
@@ -288,7 +288,7 @@
 		_initUsageLine() {
 			this.usageLine = document.createElement('div');
 			this.usageLine.className =
-				'text-text-400 text-[11px] cc-usageRow cc-hidden flex flex-row flex-nowrap items-center gap-3 w-full';
+				'text-text-400 text-[12px] cc-usageRow cc-hidden flex flex-row flex-nowrap items-center gap-3 w-full';
 
 			this.sessionGroup = document.createElement('div');
 			this.sessionGroup.className = 'cc-usageGroup cc-usageStrip';
@@ -345,7 +345,7 @@
 			this.usageRefreshBtn.className = 'cc-usageRefresh cc-tooltipTrigger';
 			this.usageRefreshBtn.setAttribute('aria-label', 'Refresh usage');
 			this.usageRefreshBtn.innerHTML = `
-				<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+				<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
 					<path d="M23 4v6h-6"></path>
 					<path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"></path>
 				</svg>

--- a/src/content/ui.js
+++ b/src/content/ui.js
@@ -50,32 +50,6 @@
 		return parts.join(' · ');
 	}
 
-	function formatRelativeUpdated(tsMs) {
-		if (typeof tsMs !== 'number' || !Number.isFinite(tsMs)) return '';
-		const sec = Math.max(0, Math.floor((Date.now() - tsMs) / 1000));
-		if (sec < 10) return 'now';
-		if (sec < 60) return `${sec}s`;
-		const min = Math.floor(sec / 60);
-		if (min < 60) return `${min}m`;
-		const h = Math.floor(min / 60);
-		if (h < 48) return `${h}h`;
-		const d = Math.floor(h / 24);
-		return `${d}d`;
-	}
-
-	function formatRelativeUpdatedTitle(tsMs) {
-		if (typeof tsMs !== 'number' || !Number.isFinite(tsMs)) return '';
-		const sec = Math.max(0, Math.floor((Date.now() - tsMs) / 1000));
-		if (sec < 8) return 'Last updated just now';
-		if (sec < 60) return `Last updated ${sec} seconds ago`;
-		const min = Math.floor(sec / 60);
-		if (min < 60) return `Last updated ${min} minutes ago`;
-		const h = Math.floor(min / 60);
-		if (h < 48) return `Last updated ${h} hours ago`;
-		const d = Math.floor(h / 24);
-		return `Last updated ${d} days ago`;
-	}
-
 	// ── Tooltip system ──
 
 	function setupTooltip(element, tooltip, { topOffset = 10 } = {}) {
@@ -178,9 +152,7 @@
 			this.refreshingUsage = false;
 
 			this.usageMetaGroup = null;
-			this.usageLastUpdatedSpan = null;
 			this.usageRefreshBtn = null;
-			this.usageLastUpdatedMs = null;
 
 			this.domObserver = null;
 		}
@@ -288,7 +260,7 @@
 		_initUsageLine() {
 			this.usageLine = document.createElement('div');
 			this.usageLine.className =
-				'text-text-400 text-[12px] cc-usageRow cc-hidden flex flex-row flex-nowrap items-center gap-3 w-full';
+				'text-text-400 text-[14px] cc-usageRow cc-hidden flex flex-row flex-nowrap items-center gap-3 w-full';
 
 			this.sessionGroup = document.createElement('div');
 			this.sessionGroup.className = 'cc-usageGroup cc-usageStrip';
@@ -336,10 +308,6 @@
 			this.usageMetaGroup = document.createElement('div');
 			this.usageMetaGroup.className = 'cc-usageMeta';
 
-			this.usageLastUpdatedSpan = document.createElement('span');
-			this.usageLastUpdatedSpan.className = 'cc-usageMetaUpdated';
-			this.usageLastUpdatedSpan.setAttribute('aria-live', 'polite');
-
 			this.usageRefreshBtn = document.createElement('button');
 			this.usageRefreshBtn.type = 'button';
 			this.usageRefreshBtn.className = 'cc-usageRefresh cc-tooltipTrigger';
@@ -356,7 +324,6 @@
 				this._refreshUsage();
 			});
 
-			this.usageMetaGroup.appendChild(this.usageLastUpdatedSpan);
 			this.usageMetaGroup.appendChild(this.usageRefreshBtn);
 			this.usageLine.appendChild(this.usageMetaGroup);
 
@@ -377,17 +344,6 @@
 				this.usageMetaGroup?.classList.remove('cc-usageMeta--busy');
 				this.refreshingUsage = false;
 			}
-		}
-
-		_renderUsageLastUpdated() {
-			if (!this.usageLastUpdatedSpan) return;
-			if (this.usageLastUpdatedMs == null) {
-				this.usageLastUpdatedSpan.textContent = '';
-				this.usageLastUpdatedSpan.removeAttribute('title');
-				return;
-			}
-			this.usageLastUpdatedSpan.textContent = formatRelativeUpdated(this.usageLastUpdatedMs);
-			this.usageLastUpdatedSpan.title = formatRelativeUpdatedTitle(this.usageLastUpdatedMs);
 		}
 
 		_setupTooltips() {
@@ -622,11 +578,6 @@
 				this.weeklyBarFill.classList.remove('cc-warn', 'cc-critical', 'cc-full');
 			}
 
-			if (hasAnyUsage) {
-				this.usageLastUpdatedMs = Date.now();
-				this._renderUsageLastUpdated();
-			}
-
 			this._renderUsageStripText();
 		}
 
@@ -669,7 +620,6 @@
 				this._renderHeader();
 			}
 
-			this._renderUsageLastUpdated();
 			this._renderUsageStripText();
 		}
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -118,7 +118,7 @@
 
 .cc-usageStrip__label {
 	font-weight: 500;
-	font-size: 11px;
+	font-size: 12px;
 	opacity: 0.75;
 	letter-spacing: 0.03em;
 	flex-shrink: 0;
@@ -129,7 +129,7 @@
 }
 
 .cc-usageStrip__meta {
-	font-size: 11px;
+	font-size: 13px;
 	line-height: 1.25;
 	opacity: 0.62;
 	font-variant-numeric: tabular-nums;
@@ -152,16 +152,6 @@
 
 .cc-usageMeta--busy {
 	opacity: 0.75;
-}
-
-.cc-usageMetaUpdated {
-	font-size: 11px;
-	opacity: 0.55;
-	letter-spacing: 0.02em;
-	white-space: nowrap;
-	max-width: 7.5rem;
-	overflow: hidden;
-	text-overflow: ellipsis;
 }
 
 .cc-usageRefresh {

--- a/src/styles.css
+++ b/src/styles.css
@@ -89,29 +89,11 @@
 .cc-usageRow {
 	position: relative;
 	z-index: 50;
-	cursor: pointer;
 	user-select: none;
-	transition: opacity 200ms ease;
 	animation: cc-fadeIn 400ms cubic-bezier(0.22, 1, 0.36, 1) 100ms both;
 }
 
-.cc-usageRow:hover {
-	opacity: 0.85;
-}
-
-.cc-usageRow:active {
-	transform: scale(0.995);
-}
-
-.cc-usageRow--dim {
-	opacity: 0.5;
-	transition: opacity 150ms ease;
-}
-
 .cc-usageGroup {
-	display: flex;
-	align-items: center;
-	gap: 8px;
 	flex: 1;
 	min-width: 0;
 }
@@ -120,15 +102,101 @@
 	width: 100%;
 }
 
-.cc-usageGroup--weekly {
+/* One horizontal line per limit: label · mini bar · compact stats + reset */
+
+.cc-usageStrip {
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+	gap: 6px;
+	min-width: 0;
+}
+
+.cc-usageStrip--end {
 	justify-content: flex-end;
 }
 
-.cc-usageText {
-	white-space: nowrap;
+.cc-usageStrip__label {
+	font-weight: 500;
+	font-size: 10px;
+	opacity: 0.75;
+	letter-spacing: 0.03em;
+	flex-shrink: 0;
+}
+
+.cc-usageStrip__bar {
+	flex-shrink: 0;
+}
+
+.cc-usageStrip__meta {
+	font-size: 10px;
+	line-height: 1.2;
+	opacity: 0.62;
 	font-variant-numeric: tabular-nums;
 	font-feature-settings: "tnum";
 	letter-spacing: 0.01em;
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.cc-usageMeta {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	flex-shrink: 0;
+	margin-left: auto;
+	padding-left: 4px;
+}
+
+.cc-usageMeta--busy {
+	opacity: 0.75;
+}
+
+.cc-usageMetaUpdated {
+	font-size: 10px;
+	opacity: 0.55;
+	letter-spacing: 0.02em;
+	white-space: nowrap;
+	max-width: 7.5rem;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.cc-usageRefresh {
+	all: unset;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	cursor: pointer;
+	opacity: 0.55;
+	padding: 2px;
+	border-radius: 4px;
+	transition: opacity 150ms ease, transform 150ms ease;
+	box-sizing: border-box;
+}
+
+.cc-usageRefresh:hover {
+	opacity: 0.95;
+}
+
+.cc-usageRefresh:active:not(:disabled) {
+	transform: scale(0.92);
+}
+
+.cc-usageRefresh:focus-visible {
+	outline: 1px solid currentColor;
+	outline-offset: 2px;
+	border-radius: 4px;
+}
+
+.cc-usageRefresh:disabled {
+	cursor: wait;
+}
+
+.cc-usageRefresh.cc-usageRefresh--busy svg {
+	animation: cc-spin 0.75s linear infinite;
 }
 
 /* ── Bars (pill-shaped, borderless) ── */

--- a/src/styles.css
+++ b/src/styles.css
@@ -118,7 +118,7 @@
 
 .cc-usageStrip__label {
 	font-weight: 500;
-	font-size: 10px;
+	font-size: 11px;
 	opacity: 0.75;
 	letter-spacing: 0.03em;
 	flex-shrink: 0;
@@ -129,8 +129,8 @@
 }
 
 .cc-usageStrip__meta {
-	font-size: 10px;
-	line-height: 1.2;
+	font-size: 11px;
+	line-height: 1.25;
 	opacity: 0.62;
 	font-variant-numeric: tabular-nums;
 	font-feature-settings: "tnum";
@@ -155,7 +155,7 @@
 }
 
 .cc-usageMetaUpdated {
-	font-size: 10px;
+	font-size: 11px;
 	opacity: 0.55;
 	letter-spacing: 0.02em;
 	white-space: nowrap;


### PR DESCRIPTION
- Single-line 5h/7d limits: mini bar, "N% used", "resets in …"
- Refresh button and compact last-updated label
- Short tooltips; README and manifest wording

<img width="347" height="201" alt="Screenshot 2026-05-02 at 4 46 59 PM" src="https://github.com/user-attachments/assets/5fc87cc7-a242-4a44-9e88-3c3cf39fcf47" />


<img width="442" height="225" alt="Screenshot 2026-05-02 at 4 47 08 PM" src="https://github.com/user-attachments/assets/c4258015-c41c-4cdd-b6e1-e089469c6448" />


<img width="337" height="117" alt="Screenshot 2026-05-02 at 4 47 22 PM" src="https://github.com/user-attachments/assets/d086f865-6021-4672-82fb-e3197a483649" />


<img width="834" height="216" alt="Screenshot 2026-05-02 at 4 46 43 PM" src="https://github.com/user-attachments/assets/b00b5380-0d01-4f95-aa3d-86895d2be46f" />
