### PR TITLE
feat: added thinking token counter display

### DIFF
--- a/src/content/main.js
+++ b/src/content/main.js
@@ -210,7 +210,7 @@
 
 		latestConversationData = data;
 		const metrics = await CC.tokens.computeConversationMetrics(data);
-		ui.setConversationMetrics({ totalTokens: metrics.totalTokens, cachedUntil: metrics.cachedUntil });
+		ui.setConversationMetrics({ totalTokens: metrics.totalTokens, thinkingTokens: metrics.thinkingTokens, cachedUntil: metrics.cachedUntil });
 	}
 
 	function handleMessageLimit(messageLimit) {

--- a/src/content/tokens.js
+++ b/src/content/tokens.js
@@ -180,6 +180,17 @@
 		return parts.join('\n');
 	}
 
+	function stringifyMessageThinking(message) {
+		const parts = [];
+		const content = Array.isArray(message?.content) ? message.content : [];
+		for (const item of content) {
+			if (item?.type === 'thinking' && typeof item.thinking === 'string') {
+				parts.push(item.thinking);
+			}
+		}
+		return parts.join('\n');
+	}
+
 	async function hashString(str) {
 		if (!CC.bridge?.requestHash) return null;
 		try {
@@ -203,15 +214,16 @@
 			this._byMessageId = new Map();
 		}
 
-		async getMessageTokens(messageId, messageText) {
+		async getMessageTokens(messageId, messageText, thinkingText) {
 			const fp = await fingerprint(messageText);
-			if (!fp) return countTokens(messageText);
+			const thinking = thinkingText ? countTokens(thinkingText) : 0;
+			if (!fp) return { tokens: countTokens(messageText), thinking };
 			const cached = this._byMessageId.get(messageId);
-			if (cached && cached.fp === fp) return cached.tokens;
+			if (cached && cached.fp === fp) return { tokens: cached.tokens, thinking: cached.thinking };
 
 			const tokens = countTokens(messageText);
-			this._byMessageId.set(messageId, { fp, tokens });
-			return tokens;
+			this._byMessageId.set(messageId, { fp, tokens, thinking });
+			return { tokens, thinking };
 		}
 
 		pruneToMessageIds(keepIds) {
@@ -230,6 +242,7 @@
 		tokenCache.pruneToMessageIds(trunkIds);
 
 		let totalTokens = 0;
+		let thinkingTokens = 0;
 		let lastAssistantMs = null;
 
 		for (const msg of trunk) {
@@ -241,15 +254,20 @@
 			}
 
 			const msgText = stringifyMessageCountables(msg);
-			const msgTokens = msg?.uuid
-				? await tokenCache.getMessageTokens(msg.uuid, msgText)
-				: countTokens(msgText);
-			totalTokens += msgTokens;
+			const thinkingText = stringifyMessageThinking(msg);
+			if (msg?.uuid) {
+				const result = await tokenCache.getMessageTokens(msg.uuid, msgText, thinkingText);
+				totalTokens += result.tokens;
+				thinkingTokens += result.thinking;
+			} else {
+				totalTokens += countTokens(msgText);
+				if (thinkingText) thinkingTokens += countTokens(thinkingText);
+			}
 		}
 
 		const cachedUntil = lastAssistantMs ? lastAssistantMs + CC.CONST.CACHE_WINDOW_MS : null;
 
-		return { trunkMessageCount: trunk.length, totalTokens, lastAssistantMs, cachedUntil };
+		return { trunkMessageCount: trunk.length, totalTokens, thinkingTokens, lastAssistantMs, cachedUntil };
 	}
 
 	CC.tokens = { computeConversationMetrics, buildTrunk, formatTrunkAsText, formatTrunkAsMarkdown };

--- a/src/content/ui.js
+++ b/src/content/ui.js
@@ -133,6 +133,8 @@
 			this.cachedDisplay = null;
 			this.lengthBar = null;
 			this.lengthTooltip = null;
+			this.thinkingDisplay = null;
+			this.thinkingTooltip = null;
 			this.lastCachedUntilMs = null;
 			this.pendingCache = false;
 
@@ -213,6 +215,8 @@
 			this.lengthGroup.className = 'cc-tooltipTrigger';
 			this.lengthDisplay = document.createElement('span');
 			this.cachedDisplay = document.createElement('span');
+			this.thinkingDisplay = document.createElement('span');
+			this.thinkingDisplay.className = 'cc-thinkingLabel';
 			this.cacheTimeSpan = null;
 
 			this.lengthGroup.appendChild(this.lengthDisplay);
@@ -352,6 +356,9 @@
 
 			setupTooltip(this.cachedDisplay, makeTooltip('Prompt cache'), { topOffset: 8 });
 
+			this.thinkingTooltip = makeTooltip('Extended thinking tokens');
+			setupTooltip(this.thinkingDisplay, this.thinkingTooltip, { topOffset: 8 });
+
 			this._copyTooltip = makeTooltip('Copy chat');
 			setupTooltip(this.copyButton, this._copyTooltip, { topOffset: 8 });
 
@@ -431,12 +438,13 @@
 			}
 		}
 
-		setConversationMetrics({ totalTokens, cachedUntil } = {}) {
+		setConversationMetrics({ totalTokens, thinkingTokens, cachedUntil } = {}) {
 			this.pendingCache = false;
 
 			if (typeof totalTokens !== 'number') {
 				this.lengthDisplay.textContent = '';
 				this.cachedDisplay.textContent = '';
+				this.thinkingDisplay.textContent = '';
 				this.lastCachedUntilMs = null;
 				this._renderHeader();
 				return;
@@ -476,6 +484,12 @@
 				);
 			}
 
+			if (typeof thinkingTokens === 'number' && thinkingTokens > 0) {
+				this.thinkingDisplay.textContent = `${formatTokens(thinkingTokens)} thinking`;
+			} else {
+				this.thinkingDisplay.textContent = '';
+			}
+
 			const now = Date.now();
 			if (typeof cachedUntil === 'number' && cachedUntil > now) {
 				this.lastCachedUntilMs = cachedUntil;
@@ -510,6 +524,13 @@
 			if (!hasTokens) return;
 
 			const items = [this.logoContainer, this.lengthGroup];
+			const hasThinking = !!this.thinkingDisplay.textContent;
+			if (hasThinking) {
+				const thinkSep = document.createElement('span');
+				thinkSep.className = 'cc-sep';
+				thinkSep.textContent = '·';
+				items.push(thinkSep, this.thinkingDisplay);
+			}
 			if (hasCache) {
 				const sep = document.createElement('span');
 				sep.className = 'cc-sep';

--- a/src/styles.css
+++ b/src/styles.css
@@ -6,28 +6,61 @@
 /* ── Keyframes ── */
 
 @keyframes cc-fadeIn {
-	from { opacity: 0; transform: translateY(-2px); }
-	to   { opacity: 1; transform: translateY(0); }
+	from {
+		opacity: 0;
+		transform: translateY(-2px);
+	}
+
+	to {
+		opacity: 1;
+		transform: translateY(0);
+	}
 }
 
 @keyframes cc-breathe {
-	0%, 100% { opacity: 1; }
-	50%      { opacity: 0.6; }
+
+	0%,
+	100% {
+		opacity: 1;
+	}
+
+	50% {
+		opacity: 0.6;
+	}
 }
 
 @keyframes cc-spin {
-	from { transform: rotate(0deg); }
-	to   { transform: rotate(360deg); }
+	from {
+		transform: rotate(0deg);
+	}
+
+	to {
+		transform: rotate(360deg);
+	}
 }
 
 @keyframes cc-barEnter {
-	from { opacity: 0; transform: scaleX(0.92); }
-	to   { opacity: 1; transform: scaleX(1); }
+	from {
+		opacity: 0;
+		transform: scaleX(0.92);
+	}
+
+	to {
+		opacity: 1;
+		transform: scaleX(1);
+	}
 }
 
 @keyframes cc-pulseWarn {
-	0%, 100% { opacity: 1; }
-	50%      { opacity: 0.7; }
+
+	0%,
+	100% {
+		opacity: 1;
+	}
+
+	50% {
+		opacity: 0.7;
+	}
 }
 
 /* ── Header: tokens + cache timer ── */
@@ -216,7 +249,7 @@
 	background: var(--cc-fill);
 	border-radius: var(--cc-radius);
 	transition: width 500ms cubic-bezier(0.22, 1, 0.36, 1),
-	            background-color 400ms ease;
+		background-color 400ms ease;
 }
 
 .cc-bar__fill.cc-warn {
@@ -290,7 +323,7 @@
 	background: rgba(0, 0, 0, 0.65);
 	color: rgba(255, 255, 255, 0.92);
 	box-shadow: 0 4px 24px rgba(0, 0, 0, 0.12),
-	            0 0 0 0.5px rgba(255, 255, 255, 0.06);
+		0 0 0 0.5px rgba(255, 255, 255, 0.06);
 	letter-spacing: 0.01em;
 }
 
@@ -364,7 +397,7 @@
 	backdrop-filter: blur(20px) saturate(1.3);
 	background: rgba(0, 0, 0, 0.7);
 	box-shadow: 0 8px 32px rgba(0, 0, 0, 0.18),
-	            0 0 0 0.5px rgba(255, 255, 255, 0.08);
+		0 0 0 0.5px rgba(255, 255, 255, 0.08);
 	animation: cc-fadeIn 150ms cubic-bezier(0.22, 1, 0.36, 1) both;
 }
 
@@ -391,6 +424,13 @@
 
 .cc-copyDropdown__item:active {
 	background: rgba(255, 255, 255, 0.18);
+}
+
+.cc-thinkingLabel {
+	opacity: 0.62;
+	font-variant-numeric: tabular-nums;
+	font-feature-settings: "tnum";
+	cursor: default;
 }
 
 /* ── Hide optional elements ── */


### PR DESCRIPTION
**Changes**
- Adds a separate thinking token counter that displays alongside the existing token count in the header. 

**Why this addition**
- Thinking tokens can consume significant context but are currently invisible. Surfacing this hidden cost helps developers debug prompt efficiency and evaluate whether the token overhead of extended thinking is actually worth it for their specific use case.

**Files modified**
- tokens.js — Added `stringifyMessageThinking()` to extract thinking block text. Modified `TokenCache `and `computeConversationMetrics()` to track thinking tokens separately.
- ui.js — Added `thinkingDisplay `element with tooltip. Renders between token count and cache timer, only when thinking tokens > 0.
- main.js — Passes `thinkingTokens` through to the UI.
- styles.css — Added `.cc-thinkingLabel` styling (dimmed, tabular-nums).

