### PR TITLE
fix: restore token header after claude.ai DOM update

### DIFF
--- a/src/content/constants.js
+++ b/src/content/constants.js
@@ -4,11 +4,23 @@
 	const CC = (globalThis.ClaudeCounter = globalThis.ClaudeCounter || {});
 
 	CC.DOM = Object.freeze({
-		CHAT_MENU_TRIGGER: '[data-testid="chat-menu-trigger"]',
+		// claude.ai removed chat-menu-trigger (~Jun 2026); try newer anchors first
+		CHAT_HEADER_ANCHORS: [
+			'[data-testid="chat-title-split"]',
+			'button:has(span.font-base-bold)',
+			'[data-testid="chat-menu-trigger"]'
+		],
 		MODEL_SELECTOR_DROPDOWN: '[data-testid="model-selector-dropdown"]',
-		CHAT_PROJECT_WRAPPER: '.chat-project-wrapper',
 		BRIDGE_SCRIPT_ID: 'cc-bridge-script'
 	});
+
+	CC.findHeaderAnchor = () => {
+		for (const selector of CC.DOM.CHAT_HEADER_ANCHORS) {
+			const el = document.querySelector(selector);
+			if (el) return el;
+		}
+		return null;
+	};
 
 	CC.CONST = Object.freeze({
 		CACHE_WINDOW_MS: 5 * 60 * 1000,

--- a/src/content/main.js
+++ b/src/content/main.js
@@ -54,6 +54,34 @@
 
 	CC.waitForElement = waitForElement;
 
+	function waitForHeaderAnchor(timeoutMs) {
+		const existing = CC.findHeaderAnchor();
+		if (existing) return Promise.resolve(existing);
+
+		return new Promise((resolve) => {
+			let timeoutId;
+			const observer = new MutationObserver(() => {
+				const el = CC.findHeaderAnchor();
+				if (el) {
+					if (timeoutId) clearTimeout(timeoutId);
+					observer.disconnect();
+					resolve(el);
+				}
+			});
+
+			observer.observe(document.body, { childList: true, subtree: true });
+
+			if (timeoutMs) {
+				timeoutId = setTimeout(() => {
+					observer.disconnect();
+					resolve(null);
+				}, timeoutMs);
+			}
+		});
+	}
+
+	CC.waitForHeaderAnchor = waitForHeaderAnchor;
+
 	function observeUrlChanges(callback) {
 		let lastPath = window.location.pathname;
 
@@ -228,7 +256,7 @@
 		waitForElement(CC.DOM.MODEL_SELECTOR_DROPDOWN, 60000).then((el) => {
 			if (el) ui.attachUsageLine();
 		});
-		waitForElement(CC.DOM.CHAT_MENU_TRIGGER, 60000).then((el) => {
+		waitForHeaderAnchor(60000).then((el) => {
 			if (el) ui.attachHeader();
 		});
 

--- a/src/content/ui.js
+++ b/src/content/ui.js
@@ -248,7 +248,7 @@
 
 				if (headerMissing && !headerReattachPending) {
 					headerReattachPending = true;
-					CC.waitForElement(CC.DOM.CHAT_MENU_TRIGGER, 60000).then((el) => {
+					CC.waitForHeaderAnchor(60000).then((el) => {
 						headerReattachPending = false;
 						if (el) this.attachHeader();
 					});
@@ -372,9 +372,7 @@
 		}
 
 		attachHeader() {
-			const chatMenu = document.querySelector(CC.DOM.CHAT_MENU_TRIGGER);
-			if (!chatMenu) return;
-			const anchor = chatMenu.closest(CC.DOM.CHAT_PROJECT_WRAPPER) || chatMenu.parentElement;
+			const anchor = CC.findHeaderAnchor();
 			if (!anchor) return;
 			if (anchor.nextElementSibling !== this.headerContainer) {
 				anchor.after(this.headerContainer);


### PR DESCRIPTION
Closes #6
Closes #7

## Summary

- Fixes the missing token count, cache timer, and export controls after Anthropic removed `data-testid="chat-menu-trigger"` and `.chat-project-wrapper` from the chat title area (~early June 2026).
- Anchors the header on `[data-testid="chat-title-split"]` with fallbacks (`button:has(span.font-base-bold)`, legacy `chat-menu-trigger`) so injection survives minor DOM variations.
- Adds `findHeaderAnchor()` / `waitForHeaderAnchor()` for initial mount and MutationObserver reattachment.

The 5h/7d usage row is unchanged — it still attaches via `model-selector-dropdown`, which remains in the current UI.

## Test plan

- [ ] Reload extension and hard-refresh claude.ai
- [ ] Open an existing chat — token count and copy/export appear next to the chat title
- [ ] Confirm cache timer shows when prompt cache is active
- [ ] Navigate between chats — header reattaches after route changes
- [ ] Confirm 5h/7d usage bars still render below the composer toolbar