### PR TITLE
fix: remount usage meters for Chat/Cowork composer

### DIFF
--- a/src/content/constants.js
+++ b/src/content/constants.js
@@ -21,6 +21,18 @@
 			'button[aria-haspopup="menu"][aria-label*="Haiku" i]',
 			'[data-testid*="model-selector"]'
 		],
+		// Home + chat composer editor (Chat/Cowork merged composer, Aug 2026+)
+		COMPOSER_EDITOR_ANCHORS: [
+			'[contenteditable="true"][role="textbox"]',
+			'div[contenteditable="true"]',
+			'[data-testid="chat-input-grid-container"] [contenteditable="true"]',
+			'.rounded-composer [contenteditable="true"]'
+		],
+		COMPOSER_SHELL_FALLBACKS: [
+			'.rounded-composer',
+			'[data-testid="chat-input-grid-container"]',
+			'fieldset'
+		],
 		BRIDGE_SCRIPT_ID: 'cc-bridge-script'
 	});
 
@@ -48,20 +60,100 @@
 		return null;
 	};
 
+	CC.findComposerEditor = () => {
+		for (const selector of CC.DOM.COMPOSER_EDITOR_ANCHORS) {
+			try {
+				const el = document.querySelector(selector);
+				if (el && el.getBoundingClientRect().height > 0) return el;
+			} catch {
+				// ignore selector exceptions
+			}
+		}
+		return null;
+	};
+
+	// Claude's composer paints a rounded shell; Chat/Cowork + model controls are
+	// absolutely positioned on an inner position:relative row. Walk from the
+	// editor to that row, then out through single-child wrappers to the shell
+	// that draws the box — so usage mounts outside the card, not inside the
+	// absolute toolbar (which overlaps Chat/Cowork after the Aug 2026 redesign).
+	CC.findComposerSurface = () => {
+		const editor = CC.findComposerEditor();
+		if (editor) {
+			let row = null;
+			let node = editor.parentElement;
+			for (let hops = 0; node && hops < 10; hops++, node = node.parentElement) {
+				if (window.getComputedStyle(node).position !== 'relative') continue;
+				const ownsAbsoluteControls = [...node.querySelectorAll('button')].some((btn) => {
+					for (let el = btn.parentElement; el && el !== node; el = el.parentElement) {
+						if (window.getComputedStyle(el).position === 'absolute') return true;
+					}
+					return false;
+				});
+				if (ownsAbsoluteControls) {
+					row = node;
+					break;
+				}
+			}
+
+			if (row) {
+				let surface = row;
+				for (let hops = 0; hops < 5; hops++) {
+					const parent = surface.parentElement;
+					if (!parent || parent === document.body || parent === document.documentElement) break;
+					// Stop before climbing into page columns that also hold
+					// disclaimer / sibling chrome — only unwrap single-child shells.
+					if (parent.children.length !== 1) break;
+					surface = parent;
+				}
+				return surface;
+			}
+		}
+
+		for (const selector of CC.DOM.COMPOSER_SHELL_FALLBACKS) {
+			try {
+				const el = document.querySelector(selector);
+				if (el) return el;
+			} catch {
+				// ignore selector exceptions
+			}
+		}
+
+		// Last resort: climb from model selector, but never return an absolute
+		// control group (that's what caused the overlap with Chat/Cowork).
+		const model = CC.findModelSelector();
+		if (!model) return null;
+		let cur = model.parentElement;
+		for (let hops = 0; cur && hops < 12; hops++, cur = cur.parentElement) {
+			const style = window.getComputedStyle(cur);
+			if (style.position === 'absolute' || style.display === 'contents') continue;
+			if (style.position === 'relative' && cur.querySelector('button')) {
+				let surface = cur;
+				for (let i = 0; i < 5; i++) {
+					const parent = surface.parentElement;
+					if (!parent || parent.children.length !== 1) break;
+					surface = parent;
+				}
+				return surface;
+			}
+		}
+		return null;
+	};
+
 	CC.CONST = Object.freeze({
 		CACHE_WINDOW_MS: 5 * 60 * 1000,
 		CONTEXT_LIMIT_TOKENS: 200000
 	});
 
 	CC.COLORS = Object.freeze({
-		PROGRESS_FILL_DARK: 'rgba(255, 255, 255, 0.45)',
-		PROGRESS_FILL_LIGHT: 'rgba(0, 0, 0, 0.30)',
-		PROGRESS_TRACK_DARK: 'rgba(255, 255, 255, 0.08)',
-		PROGRESS_TRACK_LIGHT: 'rgba(0, 0, 0, 0.06)',
+		PROGRESS_FILL_DARK: 'rgba(250, 249, 245, 0.72)',
+		PROGRESS_FILL_LIGHT: 'rgba(20, 20, 19, 0.55)',
+		PROGRESS_TRACK_DARK: 'rgba(250, 249, 245, 0.12)',
+		PROGRESS_TRACK_LIGHT: 'rgba(20, 20, 19, 0.08)',
 		PROGRESS_OUTLINE_DARK: 'transparent',
 		PROGRESS_OUTLINE_LIGHT: 'transparent',
-		PROGRESS_MARKER_DARK: 'rgba(255, 255, 255, 0.7)',
-		PROGRESS_MARKER_LIGHT: 'rgba(0, 0, 0, 0.5)',
+		PROGRESS_MARKER_DARK: 'rgba(250, 249, 245, 0.75)',
+		PROGRESS_MARKER_LIGHT: 'rgba(20, 20, 19, 0.55)',
 		AMBER_WARNING: '#d97706',
 		CRITICAL_WARNING: '#ef4444',
 		CACHE_ACTIVE_DARK: 'rgba(74, 222, 128, 0.8)',

--- a/src/content/main.js
+++ b/src/content/main.js
@@ -110,6 +110,34 @@
 
 	CC.waitForModelSelector = waitForModelSelector;
 
+	function waitForComposerSurface(timeoutMs) {
+		const existing = CC.findComposerSurface();
+		if (existing) return Promise.resolve(existing);
+
+		return new Promise((resolve) => {
+			let timeoutId;
+			const observer = new MutationObserver(() => {
+				const el = CC.findComposerSurface();
+				if (el) {
+					if (timeoutId) clearTimeout(timeoutId);
+					observer.disconnect();
+					resolve(el);
+				}
+			});
+
+			observer.observe(document.body, { childList: true, subtree: true });
+
+			if (timeoutMs) {
+				timeoutId = setTimeout(() => {
+					observer.disconnect();
+					resolve(null);
+				}, timeoutMs);
+			}
+		});
+	}
+
+	CC.waitForComposerSurface = waitForComposerSurface;
+
 	function observeUrlChanges(callback) {
 		let lastPath = window.location.pathname;
 
@@ -294,7 +322,7 @@
 	async function handleUrlChange() {
 		currentConversationId = getConversationId();
 
-		CC.waitForModelSelector(60000).then((el) => {
+		CC.waitForComposerSurface(60000).then((el) => {
 			if (el) ui.attachUsageLine();
 		});
 		CC.waitForHeaderAnchor(60000).then((el) => {

--- a/src/content/ui.js
+++ b/src/content/ui.js
@@ -103,16 +103,16 @@
 			this.pendingCache = false;
 
 			this.usageLine = null;
-			this.sessionTitleSpan = null;
-			this.sessionInlineSpan = null;
-			this.weeklyTitleSpan = null;
-			this.weeklyInlineSpan = null;
+			this.sessionPctSpan = null;
+			this.sessionRemainSpan = null;
+			this.weeklyPctSpan = null;
+			this.weeklyRemainSpan = null;
 			this._sessionUtilPct = null;
 			this._weeklyUtilPct = null;
-			this.sessionBar = null;
-			this.sessionBarFill = null;
-			this.weeklyBar = null;
-			this.weeklyBarFill = null;
+			this.sessionRing = null;
+			this.sessionRingFill = null;
+			this.weeklyRing = null;
+			this.weeklyRingFill = null;
 			this.sessionResetMs = null;
 			this.weeklyResetMs = null;
 			this.refreshingUsage = false;
@@ -144,19 +144,25 @@
 		refreshProgressChrome() {
 			const { strokeColor, trackColor, fillColor, markerColor } = this.getProgressChrome();
 
-			const applyBarChrome = (bar, { fillWarn, fillCritical } = {}) => {
-				if (!bar) return;
-				bar.style.setProperty('--cc-stroke', strokeColor);
-				bar.style.setProperty('--cc-track', trackColor);
-				bar.style.setProperty('--cc-fill', fillColor);
-				bar.style.setProperty('--cc-fill-warn', fillWarn ?? fillColor);
-				bar.style.setProperty('--cc-fill-critical', fillCritical ?? fillWarn ?? fillColor);
-				bar.style.setProperty('--cc-marker', markerColor);
+			const applyChrome = (el, { fillWarn, fillCritical } = {}) => {
+				if (!el) return;
+				el.style.setProperty('--cc-stroke', strokeColor);
+				el.style.setProperty('--cc-track', trackColor);
+				el.style.setProperty('--cc-fill', fillColor);
+				el.style.setProperty('--cc-fill-warn', fillWarn ?? fillColor);
+				el.style.setProperty('--cc-fill-critical', fillCritical ?? fillWarn ?? fillColor);
+				el.style.setProperty('--cc-marker', markerColor);
 			};
 
-			applyBarChrome(this.lengthBar, { fillWarn: fillColor });
-			applyBarChrome(this.sessionBar, { fillWarn: CC.COLORS.AMBER_WARNING, fillCritical: CC.COLORS.CRITICAL_WARNING });
-			applyBarChrome(this.weeklyBar, { fillWarn: CC.COLORS.AMBER_WARNING, fillCritical: CC.COLORS.CRITICAL_WARNING });
+			applyChrome(this.lengthBar, { fillWarn: fillColor });
+			applyChrome(this.sessionRing, {
+				fillWarn: CC.COLORS.AMBER_WARNING,
+				fillCritical: CC.COLORS.CRITICAL_WARNING
+			});
+			applyChrome(this.weeklyRing, {
+				fillWarn: CC.COLORS.AMBER_WARNING,
+				fillCritical: CC.COLORS.CRITICAL_WARNING
+			});
 		}
 
 		initialize() {
@@ -222,7 +228,7 @@
 
 				if (usageMissing && !usageReattachPending) {
 					usageReattachPending = true;
-					CC.waitForElement('.rounded-composer, [data-testid="chat-input-grid-container"], [data-testid="model-selector-dropdown"]', 60000).then((el) => {
+					CC.waitForComposerSurface(60000).then((el) => {
 						usageReattachPending = false;
 						if (el) this.attachUsageLine();
 					});
@@ -239,50 +245,81 @@
 			this.domObserver.observe(document.body, { childList: true, subtree: true });
 		}
 
+		_buildMeter() {
+			const RING_R = 9;
+			const CIRC = 2 * Math.PI * RING_R;
+
+			const meter = document.createElement('div');
+			meter.className = 'cc-meter cc-tooltipTrigger';
+
+			const ring = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+			ring.setAttribute('class', 'cc-meter__ring');
+			ring.setAttribute('viewBox', '0 0 24 24');
+			ring.setAttribute('aria-hidden', 'true');
+
+			const track = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+			track.setAttribute('class', 'cc-meter__ringTrack');
+			track.setAttribute('cx', '12');
+			track.setAttribute('cy', '12');
+			track.setAttribute('r', String(RING_R));
+
+			const fill = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+			fill.setAttribute('class', 'cc-meter__ringFill');
+			fill.setAttribute('cx', '12');
+			fill.setAttribute('cy', '12');
+			fill.setAttribute('r', String(RING_R));
+			fill.style.strokeDasharray = String(CIRC);
+			fill.style.strokeDashoffset = String(CIRC);
+
+			ring.appendChild(track);
+			ring.appendChild(fill);
+
+			const stats = document.createElement('span');
+			stats.className = 'cc-meter__stats';
+
+			const pct = document.createElement('span');
+			pct.className = 'cc-meter__pct';
+
+			const remain = document.createElement('span');
+			remain.className = 'cc-meter__remain';
+
+			stats.appendChild(pct);
+			stats.appendChild(remain);
+
+			meter.appendChild(ring);
+			meter.appendChild(stats);
+
+			return { meter, pct, remain, ring, fill, circ: CIRC };
+		}
+
+		_setRingProgress(fill, circ, pct) {
+			if (!fill) return;
+			const clamped = Math.max(0, Math.min(100, pct));
+			fill.style.strokeDashoffset = String(circ * (1 - clamped / 100));
+		}
+
 		_initUsageLine() {
 			this.usageLine = document.createElement('div');
-			this.usageLine.className =
-				'text-text-400 text-[14px] cc-usageRow flex flex-row flex-nowrap items-center gap-3 w-full';
+			this.usageLine.className = 'text-text-300 cc-usageRow';
+			this.usageLine.setAttribute('role', 'group');
+			this.usageLine.setAttribute('aria-label', 'Claude usage limits');
 
-			this.sessionGroup = document.createElement('div');
-			this.sessionGroup.className = 'cc-usageGroup cc-usageStrip';
+			const session = this._buildMeter();
+			this.sessionGroup = session.meter;
+			this.sessionPctSpan = session.pct;
+			this.sessionRemainSpan = session.remain;
+			this.sessionRing = session.ring;
+			this.sessionRingFill = session.fill;
+			this._sessionRingCirc = session.circ;
 
-			this.sessionTitleSpan = document.createElement('span');
-			this.sessionTitleSpan.className = 'cc-usageStrip__label';
-			this.sessionTitleSpan.textContent = '5h';
-
-			this.sessionBar = document.createElement('div');
-			this.sessionBar.className = 'cc-bar cc-bar--mini cc-usageStrip__bar';
-			this.sessionBarFill = document.createElement('div');
-			this.sessionBarFill.className = 'cc-bar__fill';
-			this.sessionBar.appendChild(this.sessionBarFill);
-
-			this.sessionInlineSpan = document.createElement('span');
-			this.sessionInlineSpan.className = 'cc-usageStrip__meta';
-
-			this.sessionGroup.appendChild(this.sessionTitleSpan);
-			this.sessionGroup.appendChild(this.sessionBar);
-			this.sessionGroup.appendChild(this.sessionInlineSpan);
-
-			this.weeklyGroup = document.createElement('div');
-			this.weeklyGroup.className = 'cc-usageGroup cc-usageStrip cc-usageStrip--end cc-hidden';
-
-			this.weeklyTitleSpan = document.createElement('span');
-			this.weeklyTitleSpan.className = 'cc-usageStrip__label';
-			this.weeklyTitleSpan.textContent = '7d';
-
-			this.weeklyBar = document.createElement('div');
-			this.weeklyBar.className = 'cc-bar cc-bar--mini cc-usageStrip__bar';
-			this.weeklyBarFill = document.createElement('div');
-			this.weeklyBarFill.className = 'cc-bar__fill';
-			this.weeklyBar.appendChild(this.weeklyBarFill);
-
-			this.weeklyInlineSpan = document.createElement('span');
-			this.weeklyInlineSpan.className = 'cc-usageStrip__meta';
-
-			this.weeklyGroup.appendChild(this.weeklyTitleSpan);
-			this.weeklyGroup.appendChild(this.weeklyBar);
-			this.weeklyGroup.appendChild(this.weeklyInlineSpan);
+			const weekly = this._buildMeter();
+			this.weeklyGroup = weekly.meter;
+			this.weeklyGroup.classList.add('cc-hidden');
+			this.weeklyPctSpan = weekly.pct;
+			this.weeklyRemainSpan = weekly.remain;
+			this.weeklyRing = weekly.ring;
+			this.weeklyRingFill = weekly.fill;
+			this._weeklyRingCirc = weekly.circ;
 
 			this.usageLine.appendChild(this.sessionGroup);
 			this.usageLine.appendChild(this.weeklyGroup);
@@ -295,7 +332,7 @@
 			this.usageRefreshBtn.className = 'cc-usageRefresh cc-tooltipTrigger';
 			this.usageRefreshBtn.setAttribute('aria-label', 'Refresh usage');
 			this.usageRefreshBtn.innerHTML = `
-				<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+				<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
 					<path d="M23 4v6h-6"></path>
 					<path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"></path>
 				</svg>
@@ -338,7 +375,7 @@
 			this._copyTooltip = makeTooltip('Copy chat');
 			setupTooltip(this.copyButton, this._copyTooltip, { topOffset: 8 });
 
-			this._sessionTooltip = makeTooltip('5-hour session limit');
+			this._sessionTooltip = makeTooltip('5-hour session');
 			setupTooltip(this.sessionGroup, this._sessionTooltip, { topOffset: 8 });
 
 			this._weeklyTooltip = makeTooltip('7-day limit');
@@ -366,17 +403,11 @@
 
 		attachUsageLine() {
 			if (!this.usageLine) return;
-			const composer =
-				document.querySelector('.rounded-composer') ||
-				document.querySelector('[data-testid="chat-input-grid-container"]') ||
-				document.querySelector('[data-testid="chat-input-grid-area"]') ||
-				document.querySelector('fieldset') ||
-				CC.findModelSelector()?.parentElement;
+			const surface = CC.findComposerSurface();
+			if (!surface) return;
 
-			if (!composer) return;
-
-			if (composer.nextElementSibling !== this.usageLine) {
-				composer.after(this.usageLine);
+			if (surface.previousElementSibling !== this.usageLine) {
+				surface.before(this.usageLine);
 			}
 			this.refreshProgressChrome();
 		}
@@ -491,6 +522,17 @@
 			this.headerContainer.appendChild(this.headerDisplay);
 		}
 
+		_applyMeterLevel(fill, pctEl, meterEl, width) {
+			const warn = width >= 80 && width < 95;
+			const critical = width >= 95;
+			fill?.classList.toggle('cc-warn', warn);
+			fill?.classList.toggle('cc-critical', critical);
+			pctEl?.classList.toggle('cc-meter__pct--warn', warn);
+			pctEl?.classList.toggle('cc-meter__pct--critical', critical);
+			meterEl?.classList.toggle('cc-meter--warn', warn);
+			meterEl?.classList.toggle('cc-meter--critical', critical);
+		}
+
 		setUsage(usage) {
 			this.refreshProgressChrome();
 			const session = usage?.five_hour || null;
@@ -504,21 +546,17 @@
 				this.sessionResetMs = session.resets_at ? Date.parse(session.resets_at) : null;
 
 				const width = Math.max(0, Math.min(100, rawPct));
-				this.sessionBarFill.style.width = `${width}%`;
-				this.sessionBarFill.classList.toggle('cc-warn', width >= 80 && width < 95);
-				this.sessionBarFill.classList.toggle('cc-critical', width >= 95);
-				this.sessionBarFill.classList.remove('cc-full');
-				if (width >= 99.5) this.sessionBarFill.classList.add('cc-full');
+				this._setRingProgress(this.sessionRingFill, this._sessionRingCirc, width);
+				this._applyMeterLevel(this.sessionRingFill, this.sessionPctSpan, this.sessionGroup, width);
 			} else {
 				this._sessionUtilPct = 0;
-				this.sessionBarFill.style.width = '0%';
-				this.sessionBarFill.classList.remove('cc-warn', 'cc-critical', 'cc-full');
 				this.sessionResetMs = null;
+				this._setRingProgress(this.sessionRingFill, this._sessionRingCirc, 0);
+				this._applyMeterLevel(this.sessionRingFill, this.sessionPctSpan, this.sessionGroup, 0);
 			}
 
 			const hasWeekly = weekly && typeof weekly.utilization === 'number';
 			this.weeklyGroup?.classList.toggle('cc-hidden', !hasWeekly);
-			this.sessionGroup?.classList.toggle('cc-usageGroup--single', !hasWeekly);
 
 			if (hasWeekly) {
 				const rawPct = weekly.utilization;
@@ -526,43 +564,42 @@
 				this.weeklyResetMs = weekly.resets_at ? Date.parse(weekly.resets_at) : null;
 
 				const width = Math.max(0, Math.min(100, rawPct));
-				this.weeklyBarFill.style.width = `${width}%`;
-				this.weeklyBarFill.classList.toggle('cc-warn', width >= 80 && width < 95);
-				this.weeklyBarFill.classList.toggle('cc-critical', width >= 95);
-				this.weeklyBarFill.classList.remove('cc-full');
-				if (width >= 99.5) this.weeklyBarFill.classList.add('cc-full');
+				this._setRingProgress(this.weeklyRingFill, this._weeklyRingCirc, width);
+				this._applyMeterLevel(this.weeklyRingFill, this.weeklyPctSpan, this.weeklyGroup, width);
 			} else {
 				this._weeklyUtilPct = null;
-				if (this.weeklyInlineSpan) this.weeklyInlineSpan.textContent = '';
 				this.weeklyResetMs = null;
-				this.weeklyBarFill.style.width = '0%';
-				this.weeklyBarFill.classList.remove('cc-warn', 'cc-critical', 'cc-full');
+				if (this.weeklyPctSpan) this.weeklyPctSpan.textContent = '';
+				if (this.weeklyRemainSpan) this.weeklyRemainSpan.textContent = '';
+				this._setRingProgress(this.weeklyRingFill, this._weeklyRingCirc, 0);
+				this._applyMeterLevel(this.weeklyRingFill, this.weeklyPctSpan, this.weeklyGroup, 0);
 			}
 
 			this._renderUsageStripText();
 		}
 
+		_fillMeterText(pctEl, remainEl, pct, resetMs) {
+			if (pctEl) {
+				pctEl.textContent = typeof pct === 'number' ? CC.format.formatUsagePct(pct) : '';
+			}
+			if (remainEl) {
+				remainEl.textContent = CC.format.formatRemaining(resetMs);
+			}
+		}
+
 		_renderUsageStripText() {
-			if (this.sessionInlineSpan) {
-				if (typeof this._sessionUtilPct === 'number') {
-					this.sessionInlineSpan.textContent = CC.format.formatUsageStripText(
-						this._sessionUtilPct,
-						this.sessionResetMs
-					);
-				} else {
-					this.sessionInlineSpan.textContent = '';
-				}
-			}
-			if (this.weeklyInlineSpan) {
-				if (typeof this._weeklyUtilPct === 'number') {
-					this.weeklyInlineSpan.textContent = CC.format.formatUsageStripText(
-						this._weeklyUtilPct,
-						this.weeklyResetMs
-					);
-				} else {
-					this.weeklyInlineSpan.textContent = '';
-				}
-			}
+			this._fillMeterText(
+				this.sessionPctSpan,
+				this.sessionRemainSpan,
+				this._sessionUtilPct,
+				this.sessionResetMs
+			);
+			this._fillMeterText(
+				this.weeklyPctSpan,
+				this.weeklyRemainSpan,
+				this._weeklyUtilPct,
+				this.weeklyResetMs
+			);
 		}
 
 		tick() {

--- a/src/shared/format.js
+++ b/src/shared/format.js
@@ -29,12 +29,25 @@
 			return `${days}d ${remHours}h`;
 		},
 
+		formatUsagePct(rawPct) {
+			return `${Math.round(rawPct)}%`;
+		},
+
+		formatRemaining(resetMs) {
+			if (resetMs == null || !Number.isFinite(resetMs)) return '';
+			return this.formatResetCountdown(resetMs);
+		},
+
+		formatUsageReset(resetMs) {
+			const remaining = this.formatRemaining(resetMs);
+			if (!remaining) return '';
+			return `resets in ${remaining}`;
+		},
+
 		formatUsageStripText(rawPct, resetMs) {
-			const used = Math.round(rawPct * 10) / 10;
-			const parts = [`${used}% used`];
-			if (resetMs != null && Number.isFinite(resetMs)) {
-				parts.push(`resets in ${this.formatResetCountdown(resetMs)}`);
-			}
+			const parts = [`${this.formatUsagePct(rawPct)} used`];
+			const reset = this.formatUsageReset(resetMs);
+			if (reset) parts.push(reset);
 			return parts.join(' · ');
 		}
 	};

--- a/src/styles.css
+++ b/src/styles.css
@@ -84,73 +84,112 @@
 	animation: cc-breathe 2.5s ease-in-out infinite;
 }
 
-/* ── Usage row: session + weekly ── */
+/* ── Usage strip: compact ring gauges ── */
 
 .cc-usageRow {
 	position: relative;
 	z-index: 50;
-	user-select: none;
-	animation: cc-fadeIn 400ms cubic-bezier(0.22, 1, 0.36, 1) 100ms both;
-	margin-top: 4px;
-	padding: 0 4px;
-}
-
-.cc-usageGroup {
-	flex: 1;
-	min-width: 0;
-}
-
-.cc-usageGroup--single {
-	width: 100%;
-}
-
-/* One horizontal line per limit: label · mini bar · compact stats + reset */
-
-.cc-usageStrip {
 	display: flex;
 	flex-direction: row;
+	flex-wrap: nowrap;
 	align-items: center;
-	gap: 6px;
+	justify-content: flex-start;
+	gap: 14px;
+	width: 100%;
+	box-sizing: border-box;
+	max-width: 100%;
+	margin-top: 0;
+	margin-bottom: 8px;
+	padding: 0 4px;
+	user-select: none;
+	animation: cc-fadeIn 300ms cubic-bezier(0.22, 1, 0.36, 1) both;
+	color: inherit;
+}
+
+.cc-meter {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	flex: 0 0 auto;
 	min-width: 0;
 }
 
-.cc-usageStrip--end {
-	justify-content: flex-end;
-}
-
-.cc-usageStrip__label {
-	font-weight: 500;
-	font-size: 12px;
-	opacity: 0.75;
-	letter-spacing: 0.03em;
+.cc-meter__ring {
+	width: 20px;
+	height: 20px;
 	flex-shrink: 0;
+	transform: rotate(-90deg);
+	overflow: visible;
 }
 
-.cc-usageStrip__bar {
-	flex: 1;
-	min-width: 48px;
+.cc-meter__ringTrack,
+.cc-meter__ringFill {
+	fill: none;
+	stroke-width: 2.75;
+	stroke-linecap: round;
 }
 
-.cc-usageStrip__meta {
-	font-size: 13px;
-	line-height: 1.25;
-	opacity: 0.62;
+.cc-meter__ringTrack {
+	stroke: var(--cc-track, rgba(255, 255, 255, 0.12));
+}
+
+.cc-meter__ringFill {
+	stroke: var(--cc-fill, rgba(255, 255, 255, 0.72));
+	transition: stroke-dashoffset 450ms cubic-bezier(0.22, 1, 0.36, 1),
+	            stroke 300ms ease;
+}
+
+.cc-meter__ringFill.cc-warn {
+	stroke: var(--cc-fill-warn, #d97706);
+}
+
+.cc-meter__ringFill.cc-critical {
+	stroke: var(--cc-fill-critical, #ef4444);
+	animation: cc-pulseWarn 2s ease-in-out infinite;
+}
+
+.cc-meter__stats {
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	gap: 2px;
+	min-width: 0;
+}
+
+.cc-meter__pct,
+.cc-meter__remain {
+	font-size: 12px;
+	font-weight: 500;
+	line-height: 1.15;
+	letter-spacing: 0.01em;
 	font-variant-numeric: tabular-nums;
 	font-feature-settings: "tnum";
-	letter-spacing: 0.01em;
-	min-width: 0;
-	overflow: hidden;
-	text-overflow: ellipsis;
 	white-space: nowrap;
+}
+
+.cc-meter__pct {
+	opacity: 0.88;
+}
+
+.cc-meter__pct--warn {
+	color: #d97706;
+	opacity: 1;
+}
+
+.cc-meter__pct--critical {
+	color: #ef4444;
+	opacity: 1;
+}
+
+.cc-meter__remain {
+	opacity: 0.45;
 }
 
 .cc-usageMeta {
 	display: inline-flex;
 	align-items: center;
-	gap: 6px;
+	justify-content: center;
 	flex-shrink: 0;
-	margin-left: auto;
-	padding-left: 4px;
 }
 
 .cc-usageMeta--busy {
@@ -163,15 +202,15 @@
 	align-items: center;
 	justify-content: center;
 	cursor: pointer;
-	opacity: 0.55;
-	padding: 2px;
+	opacity: 0.4;
+	padding: 3px;
 	border-radius: 4px;
 	transition: opacity 150ms ease, transform 150ms ease;
 	box-sizing: border-box;
 }
 
 .cc-usageRefresh:hover {
-	opacity: 0.95;
+	opacity: 0.9;
 }
 
 .cc-usageRefresh:active:not(:disabled) {
@@ -208,7 +247,7 @@
 	border-radius: var(--cc-radius);
 	background: var(--cc-track);
 	border: none;
-	overflow: visible;
+	overflow: hidden;
 	user-select: none;
 	animation: cc-barEnter 300ms cubic-bezier(0.22, 1, 0.36, 1) both;
 }
@@ -266,6 +305,7 @@
 .cc-bar--mini {
 	width: 56px;
 	height: 4px;
+	overflow: visible;
 }
 
 .cc-bar--usage {


### PR DESCRIPTION
## Summary
- Claude's merged Chat/Cowork composer pins toolbar controls absolutely inside the input card, so the old usage strip overlapped Chat/Cowork and the model picker.
- Usage now mounts on the outer composer shell (above the input), as compact left-aligned ring gauges showing percent used and time remaining. Window names stay in the tooltip.

## Test plan
- [ ] Reload the unpacked extension and hard-refresh claude.ai (home + an existing chat)
- [ ] Confirm the 5h/7d meters sit above the composer, left-aligned, without overlapping Chat/Cowork
- [ ] Confirm rings, percent, and remaining time update; hover shows 5-hour session / 7-day limit
- [ ] Confirm the refresh control still fetches usage
- [ ] Confirm token/cache header in an existing chat still attaches